### PR TITLE
Added a manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.rst
+include *.txt


### PR DESCRIPTION
Without it README.rst and requirements.txt are not included to source distribution. Thus when pip installing it an error occurs when executing the setup.py file.
