### PR TITLE
helpers.py: Ensure parameters are not overwritten when paging

### DIFF
--- a/stashy/helpers.py
+++ b/stashy/helpers.py
@@ -39,7 +39,7 @@ class ResourceBase(object):
             if params:
                 kw['params'] = params
             if start is not None:
-                kw['params'] = dict(start=start)
+                kw['params']['start'] = start
 
             response = self._client.get(url, **kw)
             maybe_throw(response)


### PR DESCRIPTION
When subsequent pages are requested, any request parameters were being overwritten. Instead, leave the parameters as is, and simply add in the start parameter in addition.
