### PR TITLE
Branches are a paginated resource, so they should be exposed like one

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -114,7 +114,7 @@ class Repository(ResourceBase):
             params['orderBy'] = orderBy
         if details is not None:
             params['details'] = details
-        return self._client.get(self.url('/branches'), params=params)
+        return self.paginate('/branches', params=params)
 
     @response_or_error
     def tags(self, filterText=None, orderBy=None):


### PR DESCRIPTION
This breaks backwards compatibility for the sake of providing a nicer API where the user of stashy does not have to either:
1. Perform their own de-pagination
2. Do repo.branches()['values'] to get the actual list of branches that they are interested in
