### PR TITLE
Bugfix Repo.browse and add a new 'files' method

### DIFF
--- a/stashy/helpers.py
+++ b/stashy/helpers.py
@@ -29,7 +29,7 @@ class ResourceBase(object):
             url = self._url
         return url + resource_url
 
-    def paginate(self, resource_url, params=None):
+    def paginate(self, resource_url, params=None, values_key='values'):
         url = self.url(resource_url)
 
         more = True
@@ -46,9 +46,9 @@ class ResourceBase(object):
 
             data = response.json()
 
-            if not 'values' in data:
+            if not values_key in data:
                 return
-            for item in data['values']:
+            for item in data[values_key]:
                 yield item
 
             if data['isLastPage']:

--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -136,18 +136,33 @@ class Repository(ResourceBase):
 
     default_branch = property(_get_default_branch, _set_default_branch, doc="Get or set the default branch")
 
-    def browse(self, at=None, type=False, blame='', noContent=''):
+    def files(self, path='', at=None):
+        """
+        Retrieve a page of files from particular directory of a repository. The search is done
+        recursively, so all files from any sub-directory of the specified directory will be returned.
+        """
+        params = {}
+        if at is None:
+            params['at'] = at
+        return self.paginate('/files/' + path, params)
+
+    def browse(self, path='', at=None, type=False, blame='', noContent=''):
+        """
+        Retrieve a page of content for a file path at a specified revision.
+        """
         params = {}
         if at is not None:
             params['at'] = at
-        if type is not None:
+        if type:
             params['type'] = type
-        if blame:
-            params['blame'] = blame
-        if noContent:
-            params['noContent'] = noContent
+            return response_or_error(lambda: self._client.get(self.url('/browse/' + path), params=params))()
+        else:
+            if blame:
+                params['blame'] = blame
+            if noContent:
+                params['noContent'] = noContent
 
-        return self.paginate("/browse", params=params)
+            return self.paginate("/browse/" + path, params=params, values_key='lines')
 
     def changes(self, until, since=None):
         """


### PR DESCRIPTION
Also added support for specifying the path in both methods.

(Note that the response from Repo.browse is not paginated if type=True)
