### PR TITLE
Removing response_or_error decorator from repo branches() paginated call...

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -103,20 +103,6 @@ class Repository(ResourceBase):
         return self._client.get(self.url())
 
     @response_or_error
-    def branches(self, filterText=None, orderBy=None, details=None):
-        """
-        Retrieve the branches matching the supplied filterText param.
-        """
-        params = {}
-        if filterText is not None:
-            params['filterText'] = filterText
-        if orderBy is not None:
-            params['orderBy'] = orderBy
-        if details is not None:
-            params['details'] = details
-        return self.paginate('/branches', params=params)
-
-    @response_or_error
     def tags(self, filterText=None, orderBy=None):
         """
         Retrieve the tags matching the supplied filterText param.
@@ -135,6 +121,19 @@ class Repository(ResourceBase):
     @ok_or_error
     def _set_default_branch(self, value):
         return self._client.put(self.url('/branches/default'), data=dict(id=value))
+
+    def branches(self, filterText=None, orderBy=None, details=None):
+        """
+        Retrieve the branches matching the supplied filterText param.
+        """
+        params = {}
+        if filterText is not None:
+            params['filterText'] = filterText
+        if orderBy is not None:
+            params['orderBy'] = orderBy
+        if details is not None:
+            params['details'] = details
+        return self.paginate('/branches', params=params)
 
     default_branch = property(_get_default_branch, _set_default_branch, doc="Get or set the default branch")
 


### PR DESCRIPTION
....  Pagination breaks the validation in response_or_error.

Use of pagination and the response_or_error decorator is mutually exclusive, given how it's currently authored.  The better answer may be to validate the results of the pagination generator.
