### PR TITLE
Added option to set repo permissions for groups and users

### DIFF
--- a/stashy/permissions.py
+++ b/stashy/permissions.py
@@ -90,6 +90,9 @@ class Users(ResourceBase, FilteredIterableResource):
         """
         return self._client.delete(self.url(), params=dict(name=user))
 
+class Permissions(ResourceBase):
+    groups = Nested(Groups)
+    users = Nested(Users)
 
 class RepositoryUserPermissions(Permissions):
     def _url_for(self):
@@ -194,41 +197,6 @@ class ProjectPermissions(Permissions):
 
         """
         return self._client.post(self._url_for(permission), params=dict(allow=False))
-
-class RepositoryPermissions(Permissions):
-    def _url_for(self):
-        return self.url().rstrip("/") + "/users"
-
-    @ok_or_error
-    def grant(self, user, permission):
-        """
-        Grant or revoke a repository permission to all users, i.e. set the
-        default permission.
-
-        repository permissions:
-            * REPO_READ
-            * REPO_WRITE
-            * REPO_ADMIN
-
-
-        """
-        return self._client.post(self._url_for(), params=dict(name=user,
-                                                              permission=permission))
-
-    @ok_or_error
-    def revoke(self, user):
-        """
-        Revoke a repository permission from all users, i.e. revoke the default
-        permission.
-
-        repository permissions:
-            * REPO_READ
-            * REPO_WRITE
-            * REPO_ADMIN
-
-        """
-        return self._client.post(self._url_for(), params=dict(name=user))
-
 
 update_doc(Groups.all, """
 Returns groups that have been granted at least one permission.

--- a/stashy/permissions.py
+++ b/stashy/permissions.py
@@ -91,10 +91,79 @@ class Users(ResourceBase, FilteredIterableResource):
         return self._client.delete(self.url(), params=dict(name=user))
 
 
-class Permissions(ResourceBase):
-    groups = Nested(Groups)
-    users = Nested(Users)
+class RepositoryUserPermissions(Permissions):
+    def _url_for(self):
+        return self.url().rstrip("/")
 
+    @ok_or_error
+    def grant(self, user, permission):
+        """
+        Grant or revoke a repository permission to all users, i.e. set the
+        default permission.
+
+        repository permissions:
+            * REPO_READ
+            * REPO_WRITE
+            * REPO_ADMIN
+
+
+        """
+        return self._client.put(self._url_for(), params=dict(name=user,
+                                                              permission=permission))
+
+    @ok_or_error
+    def revoke(self, user):
+        """
+        Revoke a repository permission from all users, i.e. revoke the default
+        permission.
+
+        repository permissions:
+            * REPO_READ
+            * REPO_WRITE
+            * REPO_ADMIN
+
+        """
+        return self._client.delete(self._url_for(), params=dict(name=user))
+
+class RepositoryGroupPermissions(Permissions):
+    def _url_for(self):
+        return self.url().rstrip("/")
+
+    @ok_or_error
+    def grant(self, group, permission):
+        """
+        Grant or revoke a repository permission to all groups, i.e. set the
+        default permission.
+
+        repository permissions:
+            * REPO_READ
+            * REPO_WRITE
+            * REPO_ADMIN
+
+
+        """
+        return self._client.put(self._url_for(), params=dict(name=group,
+                                                              permission=permission))
+
+    @ok_or_error
+    def revoke(self, group):
+        """
+        Revoke a repository permission from all groups, i.e. revoke the default
+        permission.
+
+        repository permissions:
+            * REPO_READ
+            * REPO_WRITE
+            * REPO_ADMIN
+
+        """
+        return self._client.delete(self._url_for(), params=dict(name=group))
+
+class RepositoryPermissions(Permissions):
+    groups = Nested(RepositoryGroupPermissions,
+                    relative_path="/groups")
+    users = Nested(RepositoryUserPermissions,
+                   relative_path="/users")
 
 class ProjectPermissions(Permissions):
     def _url_for(self, permission):


### PR DESCRIPTION
Hey,

I have added the option to set permissions for groups and users separately if anyone is interested. Usage:

`stash.projects[{PROJECT}].repos[{REPO}].repo_permissions.groups.grant('stash-users', 'REPO_ADMIN')`
`stash.projects[{PROJECT}].repos[{REPO}].repo_permissions.groups.revoke('stash-users')`

`stash.projects[{PROJECT}].repos[{REPO}].repo_permissions.users.grant('foo', 'REPO_WRITE')`
`stash.projects[{PROJECT}].repos[{REPO}].repo_permissions.users.revoke('foo')`

Also in relation to pull request https://github.com/RisingOak/stashy/pull/42, I had to switch to `PUT` as well since `POST` was returning `HTTP 405 METHOD NOT ALLOWED`
