### PR TITLE
Retrieving tags for a repository is a paginated resource

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -128,7 +128,6 @@ class Repository(ResourceBase):
         """
         return self.paginate('/forks')
 
-    @response_or_error
     def tags(self, filterText=None, orderBy=None):
         """
         Retrieve the tags matching the supplied filterText param.
@@ -138,7 +137,7 @@ class Repository(ResourceBase):
             params['filterText'] = filterText
         if orderBy is not None:
             params['orderBy'] = orderBy
-        return self._client.get(self.url('/tags'), params=params)
+        return self.paginate('/tags', params=params)
 
     @response_or_error
     def _get_default_branch(self):


### PR DESCRIPTION
Per https://developer.atlassian.com/static/rest/stash/3.11.2/stash-rest.html#idp1320704

Retrieving tags for a repository is a paged API. This matches previous changes to resolve fetch branches in a paged manner
