### PR TITLE
Restricting enum34 installs by python version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.3
   - 3.5
 install: pip install -r requirements.txt
 script: python setup.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 decorator>=3.4.0
 requests>=2.5.1
 mock
-enum34
+enum34 ; python_version < '3.4'


### PR DESCRIPTION
Should fix #90 .