### PR TITLE
Add new functions to get_all_tags similar to get_all_branches

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -190,6 +190,15 @@ class Repository(ResourceBase):
         branches = self._client.get(self.url('/branches?limit={}'.format(items)))
         return json.loads(branches.content)
 
+    def get_all_tags(self, items):
+        """
+        Return list of all tags in this project and the repository
+        :param items: limit parameter (max items in result)
+        :return:
+        """
+        tags = self._client.get(self.url('/tags?limit={}'.format(items)))
+        return json.loads(tags.content)
+
     def get_commit(self, commit):
         """
         Returns detailed information about a given commit


### PR DESCRIPTION
User should be able to get all tags as he is already able to get all branches