### PR TITLE
fix repository renaming

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -171,7 +171,7 @@ class Repository(ResourceBase):
 
         The repository's slug is derived from its name. If the name changes the slug may also change.
         """
-        return self._client.post(self.url(), data=dict(name=name))
+        return self._client.put(self.url(), data=dict(name=name))
 
     @response_or_error
     def get(self):


### PR DESCRIPTION
post -> put

in the bitbucket server v5.8.0 post creates a new repository, and put actually updates the existing one
https://docs.atlassian.com/bitbucket-server/rest/5.7.0/bitbucket-rest.html#idm45568365953232
