### PR TITLE
Fix Bitbucket bug for big changes.

### DIFF
--- a/stashy/helpers.py
+++ b/stashy/helpers.py
@@ -106,7 +106,7 @@ class ResourceBase(object):
             for item in data[values_key]:
                 yield item
 
-            if data['isLastPage']:
+            if data['isLastPage'] or data['nextPageStart'] == None:
                 more = False
             else:
                 more = True


### PR DESCRIPTION
If there are many changed files the bitbucket api doesn't not updating parameter 'isLastPage' (isLastPage is always False). The check of 'nextPageStart' paramets was added to avoid infinite loop here.