### PR TITLE
Fix branch_permissions to actually use 2.0 API

### DIFF
--- a/stashy/branch_permissions.py
+++ b/stashy/branch_permissions.py
@@ -8,17 +8,22 @@ API_NAME = 'branch-permissions'
 API_VERSION = '2.0'
 API_OVERRIDE_PATH = '{0}/{1}'.format(API_NAME, API_VERSION)
 
+
 class Matcher(Enum):
-    PATTERN='PATTERN'
-    BRANCH='BRANCH'
-    MODEL_CATEGORY='MODEL_CATEGORY'
-    MODEL_BRANCH='MODEL_BRANCH'
+    """Valid values for the matcher_type for Restriction create/update"""
+    PATTERN = 'PATTERN'
+    BRANCH = 'BRANCH'
+    MODEL_CATEGORY = 'MODEL_CATEGORY'
+    MODEL_BRANCH = 'MODEL_BRANCH'
+
 
 class RestrictionType(Enum):
-    PULL_REQUEST='pull-request-only'
-    FAST_FORWARD='fast-forward-only'
-    NO_DELETES='no-deletes'
-    READ_ONLY='read-only'
+    """Valid values for the restriction_type for Restriction create/update"""
+    PULL_REQUEST = 'pull-request-only'
+    FAST_FORWARD = 'fast-forward-only'
+    NO_DELETES = 'no-deletes'
+    READ_ONLY = 'read-only'
+
 
 class Restriction(ResourceBase):
     def __init__(self, id, url, client, parent):
@@ -40,10 +45,10 @@ class Restriction(ResourceBase):
         return self._client.delete(self.url())
 
     @staticmethod
-    def request_data(match, users, groups, keys, restriction_type, matcher_type):
+    def request_data(match, users, groups, keys, restriction_type,
+                     matcher_type):
         data = dict(type=restriction_type.value)
-        data['matcher'] = dict(type={'id': matcher_type.value},
-                               id=match)
+        data['matcher'] = dict(type={'id': matcher_type.value}, id=match)
 
         if users is not None:
             data['users'] = users
@@ -55,11 +60,19 @@ class Restriction(ResourceBase):
         return data
 
     @response_or_error
-    def update(self, match, users=None, groups=None, keys=None, restriction_type=RestrictionType.READ_ONLY, matcher_type=Matcher.PATTERN):
+    def update(self, match, users=None, groups=None, keys=None,
+               restriction_type=RestrictionType.READ_ONLY,
+               matcher_type=Matcher.PATTERN):
         """
-        Re-restrict a branch, or set of branches defined by a pattern, to a set of users and/or groups
+        Re-restrict a branch, or set of branches defined by a pattern,
+        to a set of users, groups, and access keys.
+        Warning: The REST API does not actually support a direct update of
+        branch permissions. The Restriction will be deleted and recreated instead.
+        Note: access keys need to be specified by their numerical id. labels are
+        not accepted.
         """
-        data = self.request_data(match, users, groups, keys, restriction_type, matcher_type)
+        data = self.request_data(match, users, groups, keys, restriction_type,
+                                 matcher_type)
         self.delete()
         return self._client.put(self.url(""), data=data)
 
@@ -73,16 +86,23 @@ class Restrictions(ResourceBase, IterableResource):
         return Restriction(item, self.url(item), self._client, self)
 
     @response_or_error
-    def create(self, match, users=None, groups=None, keys=None, restriction_type=RestrictionType.READ_ONLY, matcher_type=Matcher.PATTERN):
+    def create(self, match, users=None, groups=None, keys=None,
+               restriction_type=RestrictionType.READ_ONLY,
+               matcher_type=Matcher.PATTERN):
         """
-        Restrict a branch, or set of branches defined by a pattern, to a set of users, groups, and access keys
+        Restrict a branch, or set of branches defined by a pattern,
+        to a set of users, groups, and access keys.
+        Note: access keys need to be specified by their numerical id. labels are
+        not accepted.
         """
         data = Restriction.request_data(match, users, groups, keys,
                                         restriction_type, matcher_type)
 
         return self._client.post(self.url(""), data=data)
 
+
 update_doc(Restrictions.all, """Retrieve list of restrictions for a repo""")
+
 
 class BranchPermissions(ResourceBase):
     """Simple parent resource for this api, to distinguish restrictions from anything else"""

--- a/stashy/branch_permissions.py
+++ b/stashy/branch_permissions.py
@@ -74,7 +74,7 @@ class Restriction(ResourceBase):
         data = self.request_data(match, users, groups, keys, restriction_type,
                                  matcher_type)
         self.delete()
-        return self._client.put(self.url(""), data=data)
+        return self._client.post(self._parent.url(), data=data)
 
 
 class Restrictions(ResourceBase, IterableResource):


### PR DESCRIPTION
Commit e42d343ec4732a4b6092f0edca4719ac3b6346ac increased
the API version from 1 to 2 but did not actually change
the code to use the 2.0 API. Implement this now:

- POST on an existing Restriction is not allowed anymore,
  use delete/create instead in update()
- set type and matcher type correctly and add Enums to make the
  possible choices clear
- support accessKeys
- refactor code to reduce code duplication

TODO:

- Discuss: Should update() sliently do a delete() or should I remove update() and force callers to do this explicitly?
- Update documentation