### PR TITLE
.travis.yml: Attempt to fix python 2.6 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-  - '2.6'
   - '2.7'
   - '3.5'
   - '3.6'
 jobs:
   include:
+    - python: '2.6'
+      dist: trusty
     - python: '3.7'
       dist: xenial
 install: pip install -r requirements.txt


### PR DESCRIPTION
Seems the default dist was upgraded from trusty to xenial
which doesn't support python 2.6 anymore.