### PR TITLE
Adding get and put request capability for the "Allow Forks" repository-level option

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -330,7 +330,27 @@ class Repository(ResourceBase):
     settings = Nested(Settings)
     webhooks = Nested(Webhooks)
     branch_permissions = Nested(BranchPermissions, relative_path=None)
+    @response_or_error
+    def _get_forkable(self):
+        """
+        Args:
+            N/A
+        Returns:
+            (bool): True if repo is forkable, False if it is not forkable
+        """
+        return self._client.get(self.url())
 
+    @ok_or_error
+    def _set_forkable(self, value):
+        """
+        Args:
+            value (bool): True if repo should be forkable, False otherwise
+        Returns:
+            Sets value of forkable to given argument
+        """
+        return self._client.put(self.url(), data=dict(forkable=value))
+
+    forkable = property(_get_forkable, _set_forkable, doc="Get or set the allow_forks option")
 
 class Repos(ResourceBase, IterableResource):
     @response_or_error

--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -330,6 +330,7 @@ class Repository(ResourceBase):
     settings = Nested(Settings)
     webhooks = Nested(Webhooks)
     branch_permissions = Nested(BranchPermissions, relative_path=None)
+    
     @response_or_error
     def _get_forkable(self):
         """


### PR DESCRIPTION
When this code is implemented, users of stashy can change between "Allow Forks" checked and unchecked very easily. 

To make sure the "Allow Forks" repo button is checked:
`<stashy_repo_object>.forkable = True`

To make sure the "Allow Forks" repo button is not checked:
`<stashy_repo_object>.forkable = False`

Gather the current status of the allow forks option (True means "Allow Forks" is checked, False means "Allow Forks" is unchecked).
`current_setting = <stashy_repo_object>.forkable['forkable']`
