### PR TITLE
Add "Allow Forks" repo setting put and get capability

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -331,6 +331,27 @@ class Repository(ResourceBase):
     webhooks = Nested(Webhooks)
     branch_permissions = Nested(BranchPermissions, relative_path=None)
 
+    @response_or_error
+    def _get_forkable(self):
+        """
+        Args:
+            N/A
+        Returns:
+            (bool): True if repo is forkable, False if it is not forkable
+        """
+        return self._client.get(self.url())
+
+    @ok_or_error
+    def _set_forkable(self, value):
+        """
+        Args:
+            value (bool): True if repo should be forkable, False otherwise
+        Returns:
+            Sets value of forkable to given argument
+        """
+        return self._client.put(self.url(), data=dict(forkable=value))
+
+    forkable = property(_get_forkable, _set_forkable, doc="Get or set the allow_forks option")
 
 class Repos(ResourceBase, IterableResource):
     @response_or_error


### PR DESCRIPTION
This creates the capability for stashy users to easily reference the "Allow Forks" button in the BitBucket repo GUI through stashy. 

To set the "Allow Forks" setting as _checked_:
`<stashy_repo_object>.forkable = True`

To set the "Allow Forks" setting as _unchecked_:
`<stashy_repo_object>.forkable = False`

To reference the current state of the "Allow Forks" setting for a repo (returns boolean; True means "Allow Forks" is checked, False means "Allow Forks" is unchecked):
`current_setting = <stashy_repo_object>.forkable['forkable']`