### PR TITLE
Add "Is Public" Setting Modification Capability for Repos

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -330,6 +330,28 @@ class Repository(ResourceBase):
     settings = Nested(Settings)
     webhooks = Nested(Webhooks)
     branch_permissions = Nested(BranchPermissions, relative_path=None)
+       
+    @response_or_error
+    def _get_public(self):
+        """
+        Args:
+            N/A
+        Returns:
+            (bool): True if repo is public, False if it is not public
+        """
+        return self._client.get(self.url())
+
+    @ok_or_error
+    def _set_public(self, value):
+        """
+        Args:
+            value (bool): True if repo should be public, False otherwise
+        Returns:
+            Sets value of public to given argument
+        """
+        return self._client.put(self.url(), data=dict(public=value))
+
+    public = property(_get_public, _set_public, doc="Get or set the 'public' option")
 
 
 class Repos(ResourceBase, IterableResource):


### PR DESCRIPTION
This modification to stashy will add the ability to allow users to modify or check the "Is Public" setting on a repository level through the API. 

To check current status of the repo's "Is Public" setting (returns boolean; True means it _is_ public, False means it _is not_ public):
`current_privacy = <stashy_repo_or_proj_object>.public`

To ensure the repo is Public:
`<stashy_repo_or_proj_object>.public = True`

To ensure the repo is Private:
`<stashy_repo_or_proj_object>.public = False`