### PR TITLE
Include tests/ in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst
 include *.txt
 include LICENSE
+graft tests


### PR DESCRIPTION
Otherwise, users unpacking the sdist (source distribution) would not
be able to run the tests.
