### PR TITLE
Add a tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /build
 /pip-log.txt
 /docs/_build
+/.tox/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Python client for the Atlassian Bitbucket Server (formerly known as Stash) [REST
 pip install stashy
 ```
 
+## Testing
+
+```
+tox
+```
+
 ## Usage
 ```python
 import stashy

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py37
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
Users who want to run the tests would get this warning:

```
$ python3 setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in
a future version. Users looking for a generic test entry point
independent of test runner are encouraged to use tox.
```

Let's add a tox.ini to modernize this.