### PR TITLE
Removes `mock` from install_requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ jobs:
       dist: trusty
     - python: '3.7'
       dist: xenial
-install: pip install -r requirements.txt
+install: pip install -r test-requirements.txt
 script: python setup.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 decorator>=3.4.0
 requests>=2.5.1
-mock
 enum34 ; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,12 @@ import os
 from setuptools import setup
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    with open(os.path.join(os.path.dirname(__file__), fname)) as fhandle:
+        return fhandle.read()
+
+def readlines(fname):
+    with open(os.path.join(os.path.dirname(__file__), fname)) as fhandle:
+        return fhandle.readlines()
 
 setup(name='stashy',
       version="0.7",
@@ -17,8 +22,8 @@ setup(name='stashy',
       packages=['stashy', 'stashy.admin'],
       test_suite = 'tests',
       #scripts=['bin/stash'],
-      #tests_require=open('test-requirements.txt').readlines(),
-      install_requires=open('requirements.txt').readlines(),
+      tests_requires=readlines('test-requirements.txt'),
+      install_requires=readlines('requirements.txt'),
       classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+mock


### PR DESCRIPTION
The `mock` package is only needed in tests.

Update: tested in Travis-CI. See build job: https://travis-ci.com/github/mupdt/stashy/builds/204921023