### PR TITLE
Repo get_sync() and rename on move()

### DIFF
--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -196,6 +196,10 @@ class Repository(ResourceBase):
         return self._client.post(self.url('/branches', is_branches=True),
                                  data=dict(name=value, startPoint=origin_branch))
 
+    @response_or_error
+    def get_sync(self):
+        return self._client.get(self.url('/', is_sync=True))
+
     @ok_or_error
     def update_sync(self, value):
         return self._client.post(self.url('/', is_sync=True),
@@ -343,21 +347,21 @@ class Repository(ResourceBase):
         if path is not None:
             params['path'] = path
         return self.paginate('/commits', params=params)
-    
+
     def diff(self, from_branch, to_branch):
         """
         Retrieve a diff between two branches.
 
         from_branch: source branch
-        to_branch: target branch        
+        to_branch: target branch
         """
         params = {
             'from': from_branch,
             'to': to_branch,
         }
-            
+
         diff = self._client.get(self.url('/compare/diff'), params=params)
-        
+
         return json.loads(diff.content)
 
     permissions = Nested(Permissions)

--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -109,11 +109,16 @@ class Repository(ResourceBase):
         return self._client.put(self.url(), data=dict(name=name))
 
     @response_or_error
-    def move(self, newProject):
+    def move(self, newProject, name=None):
         """
-        Move the repository to the given project
+        Move the repository to the given project, optionally updating its name.
+
+        The repository's slug is derived from its name. If the name changes the slug may also change.
         """
-        return self._client.put(self.url(), data=dict(project=dict(key=newProject)))
+        data = dict(project=dict(key=newProject))
+        if name:
+            data.update(dict(name=name))
+        return self._client.put(self.url(), data=data)
 
     @response_or_error
     def get(self):


### PR DESCRIPTION
Two small improvements are proposed:
* Add Repository.get_sync() method
* Allow repo move() to rename as well (backwards-compatible)